### PR TITLE
[Hero Block] Fix Min Height

### DIFF
--- a/src/blocks/hero/init.php
+++ b/src/blocks/hero/init.php
@@ -76,7 +76,7 @@ if ( ! function_exists( 'novablocks_render_hero_block' ) ) {
 		}
 
 		$heroStyle .= 'min-height: calc(' . $heroHeight . '* var(--novablocks-1vh, 1vh)); ';
-		$foregroundStyle .= 'min-height: calc(100 * var(--novablocks-1vh, 1vh)); ';
+		$foregroundStyle .= 'min-height: calc(' . $heroHeight . ' * var(--novablocks-1vh, 1vh)); ';
 
 		if ( ! empty( $attributes['overlayFilterStyle'] ) && $attributes['overlayFilterStyle'] !== 'none' ) {
 			$mediaStyle .= 'opacity: ' . ( 1 - floatval( $attributes['overlayFilterStrength'] ) / 100 ) . '; ';

--- a/src/blocks/hero/init.php
+++ b/src/blocks/hero/init.php
@@ -69,14 +69,15 @@ if ( ! function_exists( 'novablocks_render_hero_block' ) ) {
 		}
 
 		$minHeight = floatval( $attributes['minHeightFallback'] );
-		$heroHeight = $minHeight;
+		$heroHeight = $foregroundHeight = $minHeight;
 
 		if ( 'doppler' === $attributes['scrollingEffect'] ) {
 			$heroHeight = 2 * $minHeight;
+			$foregroundHeight = 100;
 		}
 
 		$heroStyle .= 'min-height: calc(' . $heroHeight . '* var(--novablocks-1vh, 1vh)); ';
-		$foregroundStyle .= 'min-height: calc(' . $heroHeight . ' * var(--novablocks-1vh, 1vh)); ';
+		$foregroundStyle .= 'min-height: calc(' . $foregroundHeight . ' * var(--novablocks-1vh, 1vh)); ';
 
 		if ( ! empty( $attributes['overlayFilterStyle'] ) && $attributes['overlayFilterStyle'] !== 'none' ) {
 			$mediaStyle .= 'opacity: ' . ( 1 - floatval( $attributes['overlayFilterStrength'] ) / 100 ) . '; ';


### PR DESCRIPTION
**Description**
Commit 43214bd2635b29eb4edfe47d6f74cd5e1ad8fbe2 introduced a bug where the Minimum Height setting of the Hero block has no visual effect: the block stays at full height.

**How has this been tested?**
Stock WP 5.4, with and without the Rosa2 theme.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
