### PR TITLE
Replace wp_remote_get with file_get_contents

### DIFF
--- a/lib/extras.php
+++ b/lib/extras.php
@@ -916,8 +916,8 @@ function novablocks_get_theme_support() {
 }
 
 function novablocks_get_attributes_from_json( $path ) {
-	$plugin_url = novablocks_get_plugin_url();
-	$body = file_get_contents( $plugin_url . $path );
+	$plugin_path = novablocks_get_plugin_path();
+	$body = file_get_contents( $plugin_path . $path );
 
 	return json_decode( $body, true );
 }

--- a/lib/extras.php
+++ b/lib/extras.php
@@ -917,7 +917,8 @@ function novablocks_get_theme_support() {
 
 function novablocks_get_attributes_from_json( $path ) {
 	$plugin_path = novablocks_get_plugin_path();
-	$body = file_get_contents( $plugin_path . $path );
+	$filename = trailingslashit( $plugin_path ) . $path;
+	$body = file_get_contents( $filename );
 
 	return json_decode( $body, true );
 }

--- a/lib/extras.php
+++ b/lib/extras.php
@@ -917,8 +917,7 @@ function novablocks_get_theme_support() {
 
 function novablocks_get_attributes_from_json( $path ) {
 	$plugin_url = novablocks_get_plugin_url();
-	$response = wp_remote_get( $plugin_url . $path );
-	$body = wp_remote_retrieve_body( $response );
+	$body = file_get_contents( $plugin_url . $path );
 
 	return json_decode( $body, true );
 }

--- a/src/blocks/advanced-gallery/init.php
+++ b/src/blocks/advanced-gallery/init.php
@@ -19,8 +19,8 @@ if ( ! function_exists( 'novablocks_advanced_gallery_block_init' ) ) {
 add_action( 'init', 'novablocks_advanced_gallery_block_init', 20 );
 
 function novablocks_get_gallery_of_the_stars_attributes_config() {
-	$gallery_attributes = novablocks_get_attributes_from_json( '/src/components/advanced-gallery/attributes.json' );
-	$media_attributes = novablocks_get_attributes_from_json( '/src/blocks/advanced-gallery/attributes.json' );
+	$gallery_attributes = novablocks_get_attributes_from_json( 'src/components/advanced-gallery/attributes.json' );
+	$media_attributes = novablocks_get_attributes_from_json( 'src/blocks/advanced-gallery/attributes.json' );
 
 	return array_merge( $media_attributes, $gallery_attributes );
 }

--- a/src/blocks/card/init.php
+++ b/src/blocks/card/init.php
@@ -19,7 +19,7 @@ if ( ! function_exists( 'novablocks_render_card_block' ) ) {
 
 	function novablocks_render_card_block( $attributes, $content ) {
 
-		$attributes_config = novablocks_get_attributes_from_json( '/src/blocks/card/attributes.json' );
+		$attributes_config = novablocks_get_attributes_from_json( 'src/blocks/card/attributes.json' );
 		$attributes = novablocks_get_attributes_with_defaults( $attributes, $attributes_config );
 
 		$hlevel = $attributes['level'];

--- a/src/blocks/google-map/init.php
+++ b/src/blocks/google-map/init.php
@@ -22,8 +22,8 @@ if ( ! function_exists( 'novablocks_render_google_maps_block' ) ) {
 
 	function novablocks_render_google_maps_block( $attributes, $content ) {
 
-		$doppler_attributes = novablocks_get_attributes_from_json( '/src/components/scrolling-effect-controls/attributes.json' );
-		$map_attributes = novablocks_get_attributes_from_json( '/src/blocks/google-map/attributes.json' );
+		$doppler_attributes = novablocks_get_attributes_from_json( 'src/components/scrolling-effect-controls/attributes.json' );
+		$map_attributes = novablocks_get_attributes_from_json( 'src/blocks/google-map/attributes.json' );
 
 		$attributes_config = array_merge( $map_attributes, $doppler_attributes );
 

--- a/src/blocks/hero/init.php
+++ b/src/blocks/hero/init.php
@@ -19,12 +19,12 @@ if ( ! function_exists( 'novablocks_hero_block_init' ) ) {
 add_action( 'init', 'novablocks_hero_block_init' );
 
 function novablocks_get_hero_attributes_config() {
-	$block_attributes = novablocks_get_attributes_from_json( '/src/blocks/hero/attributes.json' );
+	$block_attributes = novablocks_get_attributes_from_json( 'src/blocks/hero/attributes.json' );
 
-	$alignment_attributes = novablocks_get_attributes_from_json( '/src/components/alignment-controls/attributes.json' );
-	$color_attributes = novablocks_get_attributes_from_json( '/src/components/color-controls/attributes.json' );
-	$scrolling_attributes = novablocks_get_attributes_from_json( '/src/components/scrolling-effect-controls/attributes.json' );
-	$layout_attributes = novablocks_get_attributes_from_json( '/src/components/layout-panel/attributes.json' );
+	$alignment_attributes = novablocks_get_attributes_from_json( 'src/components/alignment-controls/attributes.json' );
+	$color_attributes = novablocks_get_attributes_from_json( 'src/components/color-controls/attributes.json' );
+	$scrolling_attributes = novablocks_get_attributes_from_json( 'src/components/scrolling-effect-controls/attributes.json' );
+	$layout_attributes = novablocks_get_attributes_from_json( 'src/components/layout-panel/attributes.json' );
 
 	return array_merge( $block_attributes, $alignment_attributes, $color_attributes, $scrolling_attributes, $layout_attributes );
 }

--- a/src/blocks/media/init.php
+++ b/src/blocks/media/init.php
@@ -18,9 +18,9 @@ if ( ! function_exists( 'novablocks_media_block_init' ) ) {
 }
 
 function novablocks_get_media_attributes_config() {
-	$gallery_attributes = novablocks_get_attributes_from_json( '/src/components/advanced-gallery/attributes.json' );
-	$media_attributes = novablocks_get_attributes_from_json( '/src/blocks/media/attributes.json' );
-	$space_and_sizing_attributes = novablocks_get_attributes_from_json( '/src/filters/with-space-and-sizing-controls/attributes.json' );
+	$gallery_attributes = novablocks_get_attributes_from_json( 'src/components/advanced-gallery/attributes.json' );
+	$media_attributes = novablocks_get_attributes_from_json( 'src/blocks/media/attributes.json' );
+	$space_and_sizing_attributes = novablocks_get_attributes_from_json( 'src/filters/with-space-and-sizing-controls/attributes.json' );
 
 	return array_merge( $media_attributes, $gallery_attributes, $space_and_sizing_attributes );
 }

--- a/src/blocks/slideshow/init.php
+++ b/src/blocks/slideshow/init.php
@@ -19,12 +19,12 @@ if ( ! function_exists( 'novablocks_slideshow_block_init' ) ) {
 add_action( 'init', 'novablocks_slideshow_block_init' );
 
 function novablocks_get_slideshow_attributes_config() {
-	$block_attributes = novablocks_get_attributes_from_json( '/src/blocks/slideshow/attributes.json' );
+	$block_attributes = novablocks_get_attributes_from_json( 'src/blocks/slideshow/attributes.json' );
 
-	$alignment_attributes = novablocks_get_attributes_from_json( '/src/components/alignment-controls/attributes.json' );
-	$color_attributes = novablocks_get_attributes_from_json( '/src/components/color-controls/attributes.json' );
-	$scrolling_attributes = novablocks_get_attributes_from_json( '/src/components/scrolling-effect-controls/attributes.json' );
-	$layout_attributes = novablocks_get_attributes_from_json( '/src/components/layout-panel/attributes.json' );
+	$alignment_attributes = novablocks_get_attributes_from_json( 'src/components/alignment-controls/attributes.json' );
+	$color_attributes = novablocks_get_attributes_from_json( 'src/components/color-controls/attributes.json' );
+	$scrolling_attributes = novablocks_get_attributes_from_json( 'src/components/scrolling-effect-controls/attributes.json' );
+	$layout_attributes = novablocks_get_attributes_from_json( 'src/components/layout-panel/attributes.json' );
 
 	return array_merge( $block_attributes, $alignment_attributes, $color_attributes, $scrolling_attributes, $layout_attributes );
 }


### PR DESCRIPTION
Hey @vladolaru!

One of our clients recently reached our support because one of our recent updates broke his site.
After some debugging I realised that the attributes' default values weren't properly set and the reason was that `wp_remote_get` wasn't working. I replaced it with `file_get_contents` and everything works just fine visually..

I was wondering what could be the reason for `wp_remote_get` not to work and if there are any security concerns regarding using `file_get_contents` for this job.