### PR TITLE
Create Display section for Hero Block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nova-blocks",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/block-library/src/blocks/hero/edit.js
+++ b/packages/block-library/src/blocks/hero/edit.js
@@ -146,25 +146,23 @@ class HeroEdit extends Component {
 			<Fragment>
 				<HeroPreview { ...this.props } />
 				<BlockControls { ...this.props } />
-				<InspectorControls>
-					<LayoutControls { ...this.props } />
-					<BlockHeightControls { ...this.props } />
-					<ControlsSection label={ __( 'Display' ) } group={ __( 'Block Modules' ) }>
-						<ControlsTab label={ __( 'Settings' ) }>
-							<ControlsGroup title={ __( 'Set up elements for this block', '__plugin_txtd' ) }>
-								<ToggleGroup
-									onChange={ updateAttributes }
-									toggles={ toggles.map( toggle => {
-										return {
-											...toggle,
-											value: attributes[ toggle.attribute ]
-										}
-									} ) }
-								/>
-							</ControlsGroup>
-						</ControlsTab>
-					</ControlsSection>
-				</InspectorControls>
+				<LayoutControls { ...this.props } />
+				<BlockHeightControls { ...this.props } />
+				<ControlsSection label={ __( 'Display' ) } group={ __( 'Block Modules' ) }>
+					<ControlsTab label={ __( 'Settings' ) }>
+						<ControlsGroup title={ __( 'Set up elements for this block', '__plugin_txtd' ) }>
+							<ToggleGroup
+								onChange={ updateAttributes }
+								toggles={ toggles.map( toggle => {
+									return {
+										...toggle,
+										value: attributes[ toggle.attribute ]
+									}
+								} ) }
+							/>
+						</ControlsGroup>
+					</ControlsTab>
+				</ControlsSection>
 			</Fragment>
 		);
 	}

--- a/packages/block-library/src/blocks/hero/edit.js
+++ b/packages/block-library/src/blocks/hero/edit.js
@@ -5,9 +5,9 @@ import {
 	LayoutControls,
 	withParallax,
 	ToggleGroup,
-	ControlsDrawerContent,
 	ControlsTab,
-	ControlsSection
+	ControlsSection,
+	ControlsGroup
 } from '@novablocks/components';
 
 import { withSettings } from '@novablocks/utils';
@@ -149,20 +149,22 @@ class HeroEdit extends Component {
 				<InspectorControls>
 					<LayoutControls { ...this.props } />
 					<BlockHeightControls { ...this.props } />
+					<ControlsSection label={ __( 'Display' ) } group={ __( 'Block Modules' ) }>
+						<ControlsTab label={ __( 'Settings' ) }>
+							<ControlsGroup title={ __( 'Set up elements for this block', '__plugin_txtd' ) }>
+								<ToggleGroup
+									onChange={ updateAttributes }
+									toggles={ toggles.map( toggle => {
+										return {
+											...toggle,
+											value: attributes[ toggle.attribute ]
+										}
+									} ) }
+								/>
+							</ControlsGroup>
+						</ControlsTab>
+					</ControlsSection>
 				</InspectorControls>
-				<ControlsDrawerContent>
-					<PanelBody title={ __( 'Set up elements for this block', '__plugin_txtd' ) }>
-						<ToggleGroup
-							onChange={ updateAttributes }
-							toggles={ toggles.map( toggle => {
-								return {
-									...toggle,
-									value: attributes[ toggle.attribute ]
-								}
-							} ) }
-						/>
-					</PanelBody>
-				</ControlsDrawerContent>
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
This PR will move the content-related toggles inside the Display section to follow the pattern used in the latest blocks.