### PR TITLE
Improve Space and Sizing Component on Hero, Slideshow and Block

### DIFF
--- a/packages/block-editor/src/hooks/with-content-position-matrix/controls.js
+++ b/packages/block-editor/src/hooks/with-content-position-matrix/controls.js
@@ -17,7 +17,7 @@ const Controls = ( props ) => {
   }
 
   return (
-    <BlockControls>
+    <BlockControls group="block">
       <BlockAlignmentMatrixToolbar
         label={ __( 'Change content position' ) }
         value={ contentPosition }

--- a/packages/block-library/src/blocks/hero/attributes-spacing.json
+++ b/packages/block-library/src/blocks/hero/attributes-spacing.json
@@ -1,0 +1,6 @@
+{
+	"blockTopSpacing": {
+		"type": "number",
+		"default": 1
+	}
+}

--- a/packages/block-library/src/blocks/hero/extras.js
+++ b/packages/block-library/src/blocks/hero/extras.js
@@ -1,0 +1,20 @@
+const {addFilter} = wp.hooks;
+
+import spacingAttributes from './attributes-spacing.json';
+
+const alterAttributes = ( settings ) => {
+
+  if ( settings.name !== 'novablocks/hero' ) {
+    return settings;
+  }
+
+  return {
+    ...settings,
+    attributes: {
+      ...settings.attributes,
+      ...spacingAttributes
+    },
+  }
+}
+
+addFilter( 'blocks.registerBlockType', 'novablocks/hero/settings', alterAttributes );

--- a/packages/block-library/src/blocks/hero/index.js
+++ b/packages/block-library/src/blocks/hero/index.js
@@ -8,7 +8,7 @@ import save from './save';
 import { getRandomBetween } from "@novablocks/utils";
 import { getSvg } from "@novablocks/block-editor";
 
-import blockAttributes from "./attributes";
+import attributes from './attributes.json';
 
 import {
 	generateDefaults,
@@ -19,7 +19,8 @@ import {
 // Load deprecated file
 import deprecated from './deprecated';
 
-const attributes = Object.assign( {}, blockAttributes );
+// Load extras file
+import extras from './extras';
 
 /**
  * WordPress dependencies

--- a/packages/block-library/src/blocks/hero/init.php
+++ b/packages/block-library/src/blocks/hero/init.php
@@ -21,7 +21,8 @@ function novablocks_get_hero_attributes() {
 		'packages/block-editor/src/hooks/with-content-position-matrix/attributes.json',
 		"packages/block-editor/src/hooks/with-doppler/attributes.json",
 		"packages/block-editor/src/hooks/with-doppler/attributes-alt.json",
-		'packages/block-editor/src/hooks/with-overlay-filter-strength-controls/attributes.json',
+		"packages/block-editor/src/hooks/with-overlay-filter-strength-controls/attributes.json",
+		"packages/block-editor/src/hooks/with-space-and-sizing/attributes.json",
 	) );
 
 }

--- a/packages/block-library/src/blocks/hero/init.php
+++ b/packages/block-library/src/blocks/hero/init.php
@@ -12,6 +12,7 @@ function novablocks_get_hero_attributes() {
 
 	return novablocks_merge_attributes_from_array( array(
 		"packages/block-library/src/blocks/hero/attributes.json",
+		"packages/block-library/src/blocks/hero/attributes-spacing.json",
 
 		"packages/block-editor/src/components/color-controls/attributes.json",
 		"packages/block-editor/src/components/layout-controls/attributes.json",

--- a/packages/block-library/src/blocks/hero/init.php
+++ b/packages/block-library/src/blocks/hero/init.php
@@ -12,7 +12,6 @@ function novablocks_get_hero_attributes() {
 
 	return novablocks_merge_attributes_from_array( array(
 		"packages/block-library/src/blocks/hero/attributes.json",
-		"packages/block-library/src/blocks/hero/attributes-spacing.json",
 
 		"packages/block-editor/src/components/color-controls/attributes.json",
 		"packages/block-editor/src/components/layout-controls/attributes.json",
@@ -24,6 +23,7 @@ function novablocks_get_hero_attributes() {
 		"packages/block-editor/src/hooks/with-doppler/attributes-alt.json",
 		"packages/block-editor/src/hooks/with-overlay-filter-strength-controls/attributes.json",
 		"packages/block-editor/src/hooks/with-space-and-sizing/attributes.json",
+		"packages/block-library/src/blocks/hero/attributes-spacing.json",
 	) );
 
 }

--- a/packages/block-library/src/blocks/menu-food/style.scss
+++ b/packages/block-library/src/blocks/menu-food/style.scss
@@ -15,6 +15,29 @@
 
 	margin-bottom: 1em;
 	break-inside: avoid;
+  
+  .item-title,
+  .item-description {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  
+  .item-title {
+    display: inline-block;
+    
+    position: relative;
+    z-index: 5;
+    
+    line-height: 1.25;
+    
+    margin-bottom: 0 !important;
+    
+    background-color: var(--novablocks-bg-color);
+  }
+  
+  .item-description {
+    line-height: 1.5;
+  }
 }
 
 .nova-food-menu__section:not(:first-child) {
@@ -108,29 +131,6 @@
 
 .nova-blocks-appender {
 	flex-direction: row;
-}
-
-.item-title,
-.item-description {
-	margin-top: 0;
-	margin-bottom: 0;
-}
-
-.item-title {
-	display: inline-block;
-
-	position: relative;
-	z-index: 5;
-
-	line-height: 1.25;
-
-	margin-bottom: 0 !important;
-
-	background-color: var(--novablocks-bg-color);
-}
-
-.item-description {
-	line-height: 1.5;
 }
 
 .nova-food-menu-item__title:before {

--- a/packages/block-library/src/blocks/slideshow/attributes-spacing.json
+++ b/packages/block-library/src/blocks/slideshow/attributes-spacing.json
@@ -1,0 +1,6 @@
+{
+	"blockTopSpacing": {
+		"type": "number",
+		"default": 1
+	}
+}

--- a/packages/block-library/src/blocks/slideshow/background.js
+++ b/packages/block-library/src/blocks/slideshow/background.js
@@ -20,9 +20,7 @@ const SlideshowBackground = function( props ) {
 		objectPosition: focalPoint.x * 100 + '% ' + focalPoint.y * 100 + '%',
 	};
 
-	if ( overlayFilterStyle !== 'none' ) {
-		styles.opacity = 1 - ( overlayFilterStrength / 100 );
-	}
+	styles.opacity = 1 - ( overlayFilterStrength / 100 );
 
 	const imageURL = previewImage?.sizes?.novablocks_large?.url ||
 	                 previewImage?.sizes?.novablocks_huge?.url ||

--- a/packages/block-library/src/blocks/slideshow/extras.js
+++ b/packages/block-library/src/blocks/slideshow/extras.js
@@ -1,0 +1,20 @@
+const {addFilter} = wp.hooks;
+
+import spacingAttributes from './attributes-spacing.json';
+
+const alterAttributes = ( settings ) => {
+
+  if ( settings.name !== 'novablocks/slideshow' ) {
+    return settings;
+  }
+
+  return {
+    ...settings,
+    attributes: {
+      ...settings.attributes,
+      ...spacingAttributes
+    },
+  }
+}
+
+addFilter( 'blocks.registerBlockType', 'novablocks/slideshow/settings', alterAttributes );

--- a/packages/block-library/src/blocks/slideshow/index.js
+++ b/packages/block-library/src/blocks/slideshow/index.js
@@ -22,6 +22,9 @@ import {
 
 import blockAttributes from "./attributes";
 
+// Load extras file
+import extras from './extras';
+
 const attributes = Object.assign( {}, blockAttributes );
 
 /**

--- a/packages/block-library/src/blocks/slideshow/init.php
+++ b/packages/block-library/src/blocks/slideshow/init.php
@@ -55,7 +55,7 @@ if ( ! function_exists( 'novablocks_render_slideshow_block' ) ) {
 		}
 
 		$mediaStyle = '';
-		if ( ! empty( $attributes['overlayFilterStyle'] ) && $attributes['overlayFilterStyle'] !== 'none' ) {
+		if ( ! empty( $attributes['overlayFilterStyle'] ) ) {
 			$mediaStyle .= 'opacity: ' . ( 1 - floatval( $attributes['overlayFilterStrength'] ) / 100 ) . ';';
 		}
 
@@ -101,7 +101,9 @@ if ( ! function_exists( 'novablocks_render_slideshow_block' ) ) {
 
                     if ( ! empty( $media['focalPoint'] ) ) {
                         $thisMediaStyle = $thisMediaStyle . novablocks_get_focal_point_style( $media['focalPoint'] );
-                    } ?>
+                    }
+
+                    ?>
 
                     <div class="<?php echo esc_attr( join( ' ', $slideClasses ) ); ?>">
                         <div class="novablocks-slideshow__slide-wrap">

--- a/packages/block-library/src/blocks/slideshow/init.php
+++ b/packages/block-library/src/blocks/slideshow/init.php
@@ -21,6 +21,8 @@ function novablocks_get_slideshow_attributes() {
 		"packages/block-editor/src/hooks/with-doppler/attributes.json",
 		"packages/block-editor/src/hooks/with-doppler/attributes-alt.json",
 		'packages/block-editor/src/hooks/with-overlay-filter-strength-controls/attributes.json',
+		"packages/block-editor/src/hooks/with-space-and-sizing/attributes.json",
+		"packages/block-library/src/blocks/slideshow/attributes-spacing.json",
 	) );
 
 }

--- a/packages/core/src/blocks/core/group/controls.js
+++ b/packages/core/src/blocks/core/group/controls.js
@@ -20,8 +20,23 @@ class Inspector extends Component {
     } = this.props;
 
     const {
-      contentAlignment
+      contentAlignment,
+      align
     } = attributes;
+
+    const CAN_BE_PULLED = align === undefined;
+
+    let DEFAULT_CONTENT_ALIGNMENT =[
+      { label: 'None', value: 'pull-none' }
+    ]
+
+    if (CAN_BE_PULLED) {
+
+      DEFAULT_CONTENT_ALIGNMENT.push(
+        { label: 'Pull Left', value: 'pull-left' },
+        { label: 'Pull Right', value: 'pull-right' },
+      )
+    }
 
     return (
     <ControlsSection label={ __( 'Layout' ) }>
@@ -33,11 +48,7 @@ class Inspector extends Component {
           onChange={ ( newAlignment ) => {
             setAttributes( { contentAlignment: newAlignment } );
           } }
-          options={ [
-            { label: 'None', value: 'pull-none' },
-            { label: 'Pull Left', value: 'pull-left' },
-            { label: 'Pull Right', value: 'pull-right' },
-          ] }
+          options={ DEFAULT_CONTENT_ALIGNMENT }
         />
 
       </ControlsTab>

--- a/packages/core/src/blocks/core/group/index.js
+++ b/packages/core/src/blocks/core/group/index.js
@@ -103,21 +103,7 @@ const applyFrontEndClasses = ( extraProps, blockType, attributes ) =>{
   return extraProps;
 }
 
-function updateBlockTopSpacingAttribute( block ) {
-
-  if ( ! block?.supports?.novaBlocks?.spaceAndSizing || ! allowedBlocks.includes( block.name ) ) {
-    return block;
-  }
-
-  if ( typeof block.attributes !== 'undefined' ) {
-    block.attributes.blockTopSpacing.default = 1;
-  }
-
-  return block;
-}
-
 addFilter( 'blocks.registerBlockType', 'novablocks/group/settings', alterSettings, 1 );
-// addFilter( 'blocks.registerBlockType', 'novablocks/update-block-top-spacing-attribute', updateBlockTopSpacingAttribute, 11 );
 addFilter( 'editor.BlockEdit', 'novablocks/group/content-alignment', withControls, 1 );
 addFilter( 'blocks.getSaveContent.extraProps', 'novablocks/group/frontend-classes', applyFrontEndClasses, 1 );
 addFilter( 'editor.BlockListBlock', 'novablocks/group/addEditorBlockAttributes', addEditorBlockAttributes, 1 );

--- a/packages/core/src/blocks/core/group/index.js
+++ b/packages/core/src/blocks/core/group/index.js
@@ -117,7 +117,7 @@ function updateBlockTopSpacingAttribute( block ) {
 }
 
 addFilter( 'blocks.registerBlockType', 'novablocks/group/settings', alterSettings, 1 );
-addFilter( 'blocks.registerBlockType', 'novablocks/update-block-top-spacing-attribute', updateBlockTopSpacingAttribute, 11 );
+// addFilter( 'blocks.registerBlockType', 'novablocks/update-block-top-spacing-attribute', updateBlockTopSpacingAttribute, 11 );
 addFilter( 'editor.BlockEdit', 'novablocks/group/content-alignment', withControls, 1 );
 addFilter( 'blocks.getSaveContent.extraProps', 'novablocks/group/frontend-classes', applyFrontEndClasses, 1 );
 addFilter( 'editor.BlockListBlock', 'novablocks/group/addEditorBlockAttributes', addEditorBlockAttributes, 1 );

--- a/packages/core/src/scss/components/layout/_style.scss
+++ b/packages/core/src/scss/components/layout/_style.scss
@@ -26,9 +26,15 @@
 
 .novablocks-u-content-padding {
   
-  --novablocks-content-padding-top: calc( var(--novablocks-emphasis-top-spacing) * var(--novablocks-spacing));
-  --novablocks-content-padding-bottom: calc( var(--novablocks-emphasis-bottom-spacing) * var(--novablocks-spacing));
+  --novablocks-element-spacing-multiplier: 2;
+  
+  --novablocks-content-padding-top: calc( var(--novablocks-emphasis-top-spacing) * var(--novablocks-spacing) * var(--novablocks-element-spacing-multiplier, 1));
+  --novablocks-content-padding-bottom: calc( var(--novablocks-emphasis-bottom-spacing) * var(--novablocks-spacing) * var(--novablocks-element-spacing-multiplier, 1));
   
   padding-top: var(--novablocks-content-padding-top);
   padding-bottom: var(--novablocks-content-padding-bottom);
+  
+  > * {
+    --novablocks-element-spacing-multiplier: 1;
+  }
 }


### PR DESCRIPTION
This PR will smooth some things introduced by https://github.com/pixelgrade/nova-blocks/pull/329, plus a few more changes like:
- Pull Left and Pull Right options will be available only when the block is not Wide or Full.
- Fixed Slideshow Overlay.
- Fixed Alignment Matrix Control displaying.
- Update default block top spacing value for Hero and Slideshow.
- Improve spacing for Group blocks nested in another Group block.
- Improve CSS specificity for `.item-title` inside Food Menu Block.