### PR TITLE
Fix content position deprecated

### DIFF
--- a/packages/block-editor/src/filters/with-color-signal/update-blocks.js
+++ b/packages/block-editor/src/filters/with-color-signal/update-blocks.js
@@ -31,11 +31,14 @@ subscribe( () => {
 const updateBlock = ( block ) => {
 
   const supports = getSupports( block.name );
+  const { attributes, clientId } = block;
+  const { colorSignal, palette, paletteVariation, useSourceColorAsReference } = attributes;
 
-  if ( supports?.novaBlocks?.colorSignal ) {
+  if ( supports?.novaBlocks?.colorSignal &&
+       typeof colorSignal !== "undefined" &&
+       typeof palette !== "undefined" &&
+       typeof paletteVariation !== "undefined" ) {
     const { updateBlockAttributes } = dispatch( 'core/block-editor' );
-    const { attributes, clientId } = block;
-    const { colorSignal, paletteVariation, useSourceColorAsReference } = attributes;
     const parentVariation = getParentVariation( clientId );
     const absoluteVariation = getAbsoluteColorVariation( attributes );
     const nextVariation = computeColorSignal( parentVariation, colorSignal, absoluteVariation );

--- a/packages/block-editor/src/filters/with-content-position-matrix/index.js
+++ b/packages/block-editor/src/filters/with-content-position-matrix/index.js
@@ -100,6 +100,7 @@ const withContentPositionMatrixDeprecated = ( settings ) => {
   return Object.assign( {}, settings, {
     deprecated: [ {
       attributes: {
+        ...settings.attributes,
         horizontalAlignment: {
           type: "string",
           default: "center"
@@ -112,11 +113,11 @@ const withContentPositionMatrixDeprecated = ( settings ) => {
       isEligible( attributes ) {
         return ! isUndefined( attributes.horizontalAlignment ) && ! isUndefined( attributes.verticalAlignment ) && isUndefined( attributes.contentPosition );
       },
-      migrate( oldAttributes ) {
-        const { horizontalAlignment, verticalAlignment, ...attributes } = oldAttributes;
+      migrate( attributes ) {
+        const { horizontalAlignment, verticalAlignment, ...newAttributes } = attributes;
 
         return {
-          ...attributes,
+          ...newAttributes,
           contentPosition: `${ verticalAlignment } ${ horizontalAlignment }`
         };
       },

--- a/packages/block-library/src/blocks/media/attributes.json
+++ b/packages/block-library/src/blocks/media/attributes.json
@@ -11,14 +11,6 @@
 		"type": "string",
 		"default": "moderate"
 	},
-	"horizontalAlignment": {
-		"type": "string",
-		"default": "center"
-	},
-	"verticalAlignment": {
-		"type": "string",
-		"default": ""
-	},
 	"layoutPreset": {
 		"type": "string",
 		"default": "stable"


### PR DESCRIPTION
**Description**
The deprecated method introduced for updating content position to the MatrixToolbar control was removing attributes. It also caused the `updateBlock` method from the Color Signal component to be called, and since it wasn't yet added to the block settings, it entered an infinite loop.

**Types of changes**
What types of changes does your code introduce?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)