### PR TITLE
Consume the independent Style Manager Rail Gap token

### DIFF
--- a/packages/core/src/scss/_layout.scss
+++ b/packages/core/src/scss/_layout.scss
@@ -29,7 +29,9 @@
     --block-content-end: ce;
   }
 
-  --nb-sidecar-gap: calc(var(--nb-spacing) * 2);
+  // Style Manager may tune the content-to-rail gutter independently from the
+  // global rhythm. The fallback preserves the historical 2x spacing contract.
+  --nb-sidecar-gap: calc(var(--nb-spacing) * var(--sm-rail-gap, 2));
 
   --nb-content-inset-setting: 288;
 

--- a/tests/node/sidecar-rail-gap-contract.test.cjs
+++ b/tests/node/sidecar-rail-gap-contract.test.cjs
@@ -1,0 +1,20 @@
+const assert = require( 'node:assert/strict' );
+const fs = require( 'node:fs' );
+const path = require( 'node:path' );
+const test = require( 'node:test' );
+
+const layoutSource = fs.readFileSync(
+	path.resolve( __dirname, '../../packages/core/src/scss/_layout.scss' ),
+	'utf8'
+);
+
+test( 'Sidecar derives its gutter from the Style Manager rail-gap token with the legacy fallback', () => {
+	assert.match(
+		layoutSource,
+		/--nb-sidecar-gap:\s*calc\(var\(--nb-spacing\)\s*\*\s*var\(--sm-rail-gap,\s*2\)\);/
+	);
+	assert.doesNotMatch(
+		layoutSource,
+		/--nb-sidecar-gap:\s*calc\(var\(--nb-spacing\)\s*\*\s*2\);/
+	);
+} );


### PR DESCRIPTION
Summary\n\n- Consume the new Style Manager rail-gap token in Sidecar anatomy.\n- Preserve the historical two-times-spacing gutter when the token is absent.\n- Add a source-level contract test for fallback and token ownership.\n\nCross-repo implementation for pixelgrade/style-manager#200.\n\nVerification\n\n- Production build completed.\n- All fast tests passed: 31 PHP contracts, Node contracts, Jest, and Jest compatibility.\n- Live Studio at Rail Gap 1.5: 70px to 52.5px on frontend and 48px in editor canvas; rail width and global Spacing Level remained unchanged.