### PR TITLE
Add design-system facet choice styles

### DIFF
--- a/docs/plans/2026-08-31-facet-choice-control-styling-design.md
+++ b/docs/plans/2026-08-31-facet-choice-control-styling-design.md
@@ -1,0 +1,44 @@
+# Facet choice control styling
+
+Date: 2026-08-31
+
+## Decision
+
+Nova Blocks owns the adapter between Pixelgrade Filters' established `.facetwp-*`
+markup and the LT design system. Anima continues to own native form-control semantics;
+it should not gain plugin-specific selectors.
+
+The `novablocks/facetwp-facet` block will expose a `choiceStyle` setting:
+
+- `auto` (default): preserve established behavior — radio facets render as text choices,
+  checkbox facets render as controls.
+- `controls`: render both checkbox and radio facets with visible design-system indicators.
+- `text`: render both checkbox and radio facets as indicatorless text choices.
+
+This gives Julia LT's multi-select checkbox facets the Mies LT visual treatment without
+changing their FacetWP filtering semantics, while leaving existing content byte-compatible
+until an author selects a non-default style.
+
+## Visual and interaction contract
+
+- Scope all rules to `.nb-facetwp-facet`; Nova must not restyle arbitrary FacetWP output.
+- Consume the existing Anima/Style Manager input, palette, radius, spacing, and transition
+  tokens, with Nova-safe fallbacks. Add no new global token.
+- Remove Pixelgrade Filters' bitmap checkbox/radio images inside the Nova adapter.
+- Controls: square checkbox, circular radio, palette-aware checked fill, hover feedback,
+  visible `:focus-visible`, disabled treatment, and coarse-pointer target sizing.
+- Text: no indicator, Mies-compatible underline on hover/focus/selection, stronger selected
+  weight, visible focus outline, and the same disabled treatment.
+- Support both FacetWP state signals: `.checked` and `[aria-checked="true"]`.
+- Respect reduced-motion preferences.
+
+## Verification
+
+1. Contract test fails before implementation and passes after it covers the attribute,
+   inspector control, renderer class, scoped selectors, state selectors, palette tokens,
+   focus treatment, and absence of bitmap dependencies.
+2. Full Nova fast suite passes under Node 22.
+3. Runtime bundle builds under Node 22.
+4. Local Julia LT shows both Controls and Text styles, filters with mouse and keyboard,
+   preserves multi-select behavior, and has visible focus.
+5. Local Mies LT remains visually unchanged under `auto` and still filters correctly.

--- a/packages/block-library/src/blocks/facetwp-facet/attributes.json
+++ b/packages/block-library/src/blocks/facetwp-facet/attributes.json
@@ -10,5 +10,9 @@
 	"hideLabels": {
 		"type": "boolean",
 		"default": false
+	},
+	"choiceStyle": {
+		"type": "string",
+		"default": "auto"
 	}
 }

--- a/packages/block-library/src/blocks/facetwp-facet/edit.js
+++ b/packages/block-library/src/blocks/facetwp-facet/edit.js
@@ -1,6 +1,6 @@
 import { useBlockProps } from "@wordpress/block-editor";
 import ServerSideRender from "@wordpress/server-side-render";
-import { IconButton, SelectControl, ToggleControl, Toolbar } from "@wordpress/components";
+import { IconButton, RadioControl, ToggleControl, Toolbar } from "@wordpress/components";
 import { BlockControls } from "@wordpress/block-editor";
 import { Fragment, useEffect, useMemo, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
@@ -73,11 +73,21 @@ const Edit = ( props ) => {
 
 const FacetInspectorControls = ( props ) => {
   const { attributes, setAttributes } = props;
-  const { hideLabels, hideCounts } = attributes;
+  const { choiceStyle, hideLabels, hideCounts } = attributes;
 
   return (
     <ControlsSection id={ 'setup' } label={ __( 'Setup', '__plugin_txtd' ) } placement={ 'settings' }>
       <ControlsTab label={ __( 'Settings', '__plugin_txtd' ) }>
+        <RadioControl
+          label={ __( 'Choice Style', '__plugin_txtd' ) }
+          selected={ choiceStyle }
+          options={ [
+            { label: __( 'Automatic', '__plugin_txtd' ), value: 'auto' },
+            { label: __( 'Controls', '__plugin_txtd' ), value: 'controls' },
+            { label: __( 'Text', '__plugin_txtd' ), value: 'text' },
+          ] }
+          onChange={ choiceStyle => setAttributes( { choiceStyle } ) }
+        />
         <ToggleControl
           label={__( 'Hide Label', '__plugin_txtd' )}
           checked={ hideLabels }

--- a/packages/block-library/src/blocks/facetwp-facet/index.test.js
+++ b/packages/block-library/src/blocks/facetwp-facet/index.test.js
@@ -1,0 +1,57 @@
+const test = require( 'node:test' );
+const assert = require( 'node:assert/strict' );
+const fs = require( 'node:fs' );
+const path = require( 'node:path' );
+
+const read = ( file ) => fs.readFileSync( path.join( __dirname, file ), 'utf8' );
+
+test( 'Facet choice appearance is author-selectable and backwards compatible', () => {
+	const attributes = JSON.parse( read( 'attributes.json' ) );
+	const editor = read( 'edit.js' );
+	const renderer = read( 'init.php' );
+
+	assert.deepEqual( attributes.choiceStyle, {
+		type: 'string',
+		default: 'auto',
+	} );
+	assert.match( editor, /label=\{\s*__\( 'Choice Style'/ );
+	assert.match( editor, /selected=\{\s*choiceStyle\s*\}/ );
+	assert.match( editor, /Automatic/ );
+	assert.match( editor, /Controls/ );
+	assert.match( editor, /Text/ );
+	assert.match( editor, /setAttributes\( \{ choiceStyle \} \)/ );
+	assert.match( renderer, /in_array\([\s\S]*\[\s*'auto',\s*'controls',\s*'text'\s*\][\s\S]*true/ );
+	assert.match( renderer, /nb-facetwp-facet--choice-style-/ );
+	assert.match( renderer, /\$choice_style/ );
+} );
+
+test( 'Facet choices consume design-system controls and keep the Mies text treatment', () => {
+	const style = read( 'style.scss' );
+	const filterStyle = read( '../facetwp-filter/style.scss' );
+
+	assert.match( style, /\.nb-facetwp-facet\s*\{/ );
+	assert.match( style, /--theme-checkbox-width/ );
+	assert.match( style, /--theme-input-box-shadow/ );
+	assert.match( style, /--theme-input-hover-box-shadow/ );
+	assert.match( style, /--sm-current-accent-color/ );
+	assert.match( style, /--sm-current-bg-color/ );
+	assert.match( style, /--nb-accent-color,\s*currentColor/ );
+	assert.match( style, /--nb-bg-color,\s*transparent/ );
+	assert.match( style, /--theme-input-border-radius/ );
+	assert.match( style, /--theme-transition-duration-quick/ );
+
+	assert.match( style, /&--choice-style-controls/ );
+	assert.match( style, /&--choice-style-auto[\s\S]*\.facetwp-checkbox/ );
+	assert.match( style, /&--choice-style-text/ );
+	assert.match( style, /&--choice-style-auto[\s\S]*\.facetwp-radio/ );
+	assert.match( style, /:focus-visible/ );
+	assert.match( style, /\[aria-checked=["']true["']\]/ );
+	assert.match( style, /\[aria-disabled=["']true["']\]/ );
+	assert.match( style, /@media\s*\(pointer:\s*coarse\)/ );
+	assert.match( style, /@media\s*\(prefers-reduced-motion:\s*reduce\)/ );
+	assert.doesNotMatch( style, /checkbox\.png|radio\.png/ );
+
+	assert.match( filterStyle, /\.facetwp-type-checkboxes/ );
+	assert.match( filterStyle, /\.facetwp-type-radio/ );
+	assert.match( filterStyle, /flex-direction:\s*column/ );
+} );

--- a/packages/block-library/src/blocks/facetwp-facet/index.test.js
+++ b/packages/block-library/src/blocks/facetwp-facet/index.test.js
@@ -48,7 +48,13 @@ test( 'Facet choices consume design-system controls and keep the Mies text treat
 	assert.match( style, /\[aria-checked=["']true["']\]/ );
 	assert.match( style, /\[aria-disabled=["']true["']\]/ );
 	assert.match( style, /@media\s*\(pointer:\s*coarse\)/ );
+	assert.match( style, /@media\s*\(pointer:\s*coarse\)[\s\S]*min-block-size:\s*44px/ );
+	assert.match( style, /@media\s*\(pointer:\s*coarse\)[\s\S]*min-inline-size:\s*44px/ );
 	assert.match( style, /@media\s*\(prefers-reduced-motion:\s*reduce\)/ );
+	assert.match(
+		style,
+		/:is\(\.facetwp-checkbox, \.facetwp-radio\)[\s\S]*background:\s*none\s*!important/,
+	);
 	assert.doesNotMatch( style, /checkbox\.png|radio\.png/ );
 
 	assert.match( filterStyle, /\.facetwp-type-checkboxes/ );

--- a/packages/block-library/src/blocks/facetwp-facet/init.php
+++ b/packages/block-library/src/blocks/facetwp-facet/init.php
@@ -34,8 +34,13 @@ if ( ! function_exists( 'novablocks_render_facetwp_facet_block' ) ) {
 		$attributes_config = novablocks_get_facetwp_facet_attributes();
 		$attributes        = novablocks_get_attributes_with_defaults( $attributes, $attributes_config );
 
+		$choice_style = in_array( $attributes['choiceStyle'], [ 'auto', 'controls', 'text' ], true )
+			? $attributes['choiceStyle']
+			: 'auto';
+
 		$classes = [
 			'nb-facetwp-facet',
+			'nb-facetwp-facet--choice-style-' . $choice_style,
 		];
 
 		$facets = novablocks_get_facets();

--- a/packages/block-library/src/blocks/facetwp-facet/style.scss
+++ b/packages/block-library/src/blocks/facetwp-facet/style.scss
@@ -1,51 +1,138 @@
-:is(.facetwp-type-radio, #specific) {
+.nb-facetwp-facet {
+  --nb-facetwp-choice-size: var(--theme-checkbox-width, 1.38rem);
+  --nb-facetwp-choice-gap: var(--theme-input-horizontal-spacing, 0.5em);
+  --nb-facetwp-choice-accent: var(--sm-current-accent-color, var(--nb-accent-color, currentColor));
+  --nb-facetwp-choice-background: var(--sm-current-bg-color, var(--nb-bg-color, transparent));
+  --nb-facetwp-choice-transition-duration: var(--theme-transition-duration-quick, 0.15s);
+  --nb-facetwp-choice-transition-easing: var(--theme-transition-easing, ease);
 
-  .facetwp-radio {
-    background: none !important;
-    padding: 0;
-    margin: 0;
+  :is(.facetwp-checkbox, .facetwp-radio) {
+    position: relative;
 
     display: flex;
-    gap: 0.25em;
+    align-items: center;
+    inline-size: fit-content;
+    min-block-size: var(--nb-facetwp-choice-size);
+    padding: 0;
+    margin: 0;
+    gap: var(--nb-facetwp-choice-gap);
+
+    color: inherit;
+    background: none !important;
+    cursor: pointer;
+
+    transition:
+      color var(--nb-facetwp-choice-transition-duration) var(--nb-facetwp-choice-transition-easing),
+      opacity var(--nb-facetwp-choice-transition-duration) var(--nb-facetwp-choice-transition-easing);
+  }
+
+  :is(.facetwp-checkbox, .facetwp-radio):focus-visible {
+    outline: 2px solid var(--nb-facetwp-choice-accent);
+    outline-offset: 2px;
+  }
+
+  :is(.facetwp-checkbox, .facetwp-radio):is(.disabled, [aria-disabled="true"]) {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 
   .facetwp-display-value {
     padding: 0;
   }
 
-  * {
+  :is(.facetwp-checkbox, .facetwp-radio) * {
     font-weight: inherit;
   }
 
-  // Active Facet
-  .facetwp-radio:is(.checked) {
-    text-decoration: underline;
-    font-weight: bolder;
+  // Visible design-system indicators. Automatic keeps the established Mies
+  // radio treatment while bringing checkbox facets into the same system.
+  &--choice-style-controls :is(.facetwp-checkbox, .facetwp-radio),
+  &--choice-style-auto .facetwp-checkbox {
+    &:before {
+      content: "";
+
+      flex: 0 0 var(--nb-facetwp-choice-size);
+      inline-size: var(--nb-facetwp-choice-size);
+      block-size: var(--nb-facetwp-choice-size);
+
+      background-color: var(--nb-facetwp-choice-background);
+      border-radius: var(--theme-input-border-radius, 0);
+      box-shadow: var(--theme-input-box-shadow, 0 0 0 1px currentColor);
+
+      transition:
+        background-color var(--nb-facetwp-choice-transition-duration) var(--nb-facetwp-choice-transition-easing),
+        box-shadow var(--nb-facetwp-choice-transition-duration) var(--nb-facetwp-choice-transition-easing);
+    }
+
+    &:hover:not(.disabled):not([aria-disabled="true"]):before {
+      box-shadow: var(--theme-input-hover-box-shadow, 0 0 0 2px var(--nb-facetwp-choice-accent));
+    }
   }
 
-  // Hover Facet
-  .facetwp-radio:is(:hover:not(.disabled)) {
-    text-decoration: underline;
+  &--choice-style-controls .facetwp-radio:before {
+    border-radius: 50%;
+  }
+
+  &--choice-style-controls :is(.facetwp-checkbox, .facetwp-radio):is(.checked, [aria-checked="true"]):before,
+  &--choice-style-auto .facetwp-checkbox:is(.checked, [aria-checked="true"]):before {
+    background-color: var(--nb-facetwp-choice-accent);
+    box-shadow: 0 0 0 1px var(--nb-facetwp-choice-accent);
+  }
+
+  &--choice-style-controls .facetwp-checkbox:is(.checked, [aria-checked="true"]):after,
+  &--choice-style-auto .facetwp-checkbox:is(.checked, [aria-checked="true"]):after {
+    content: "";
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-start: 0;
+
+    inline-size: var(--nb-facetwp-choice-size);
+    block-size: var(--nb-facetwp-choice-size);
+    transform: translateY(-50%);
+
+    background-color: var(--nb-facetwp-choice-background);
+    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m3.5 8.5 3 3 6-7'/%3E%3C/svg%3E") center / 62% 62% no-repeat;
+  }
+
+  &--choice-style-controls .facetwp-radio:is(.checked, [aria-checked="true"]):before {
+    box-shadow:
+      inset 0 0 0 0.36em var(--nb-facetwp-choice-background),
+      0 0 0 1px var(--nb-facetwp-choice-accent);
+  }
+
+  // Indicatorless choices retain the established Mies interaction language.
+  &--choice-style-text :is(.facetwp-checkbox, .facetwp-radio),
+  &--choice-style-auto .facetwp-radio {
+    &:is(:hover, :focus-visible):not(.disabled):not([aria-disabled="true"]),
+    &:is(.checked, [aria-checked="true"]) {
+      text-decoration: underline;
+      text-decoration-thickness: from-font;
+      text-underline-offset: 0.12em;
+    }
+
+    &:is(.checked, [aria-checked="true"]) {
+      font-weight: bolder;
+    }
   }
 }
 
-.facetwp-checkbox.disabled, .facetwp-radio.disabled {
-    opacity: 0.4;
-    cursor: default;
+.nb-facetwp-facet--hide-counts .facetwp-counter {
+  display: none;
 }
 
+.nb-facetwp-facet--hide-labels .nb-facetwp-facet__label {
+  display: none;
+}
 
-
-.nb-facetwp-facet--hide-counts {
-
-  .facetwp-counter {
-    display: none;
+@media (pointer: coarse) {
+  .nb-facetwp-facet :is(.facetwp-checkbox, .facetwp-radio) {
+    min-block-size: 44px;
   }
 }
 
-.nb-facetwp-facet--hide-labels {
-
-  .nb-facetwp-facet__label {
-    display: none;
+@media (prefers-reduced-motion: reduce) {
+  .nb-facetwp-facet :is(.facetwp-checkbox, .facetwp-radio),
+  .nb-facetwp-facet :is(.facetwp-checkbox, .facetwp-radio):before {
+    transition-duration: 0.01ms;
   }
 }

--- a/packages/block-library/src/blocks/facetwp-facet/style.scss
+++ b/packages/block-library/src/blocks/facetwp-facet/style.scss
@@ -127,6 +127,7 @@
 @media (pointer: coarse) {
   .nb-facetwp-facet :is(.facetwp-checkbox, .facetwp-radio) {
     min-block-size: 44px;
+    min-inline-size: 44px;
   }
 }
 

--- a/packages/block-library/src/blocks/facetwp-filter/style.scss
+++ b/packages/block-library/src/blocks/facetwp-filter/style.scss
@@ -95,7 +95,7 @@
 
   }
 
-  :is(.facetwp-type-radio) {
+  :is(.facetwp-type-checkboxes, .facetwp-type-radio) {
     display: flex;
     flex-wrap: wrap;
     gap: calc( var(--nb-spacing) * 0.5 );
@@ -112,7 +112,7 @@
     margin-bottom: var(--theme-spacing-smallest);
   }
 
-  :is(.facetwp-type-radio) {
+  :is(.facetwp-type-checkboxes, .facetwp-type-radio) {
     display: flex;
     flex-direction: column;
     gap: calc( var(--theme-spacing-smallest) * 0.5 );


### PR DESCRIPTION
## Summary
- add automatic, visible-control, and indicatorless text treatments to Nova facet blocks
- adapt Pixelgrade Filters checkbox/radio markup to existing Style Manager and Anima tokens
- preserve the Mies text treatment while allowing Julia checkbox facets to use it
- add focus, disabled, checked/ARIA, reduced-motion, and 44×44 coarse-pointer contracts

## Test plan
- [x] Node 22 `npm test` — 40 PHP contracts plus Node/Jest/compatibility
- [x] Node 22 production build
- [x] authenticated Julia Site Editor and Post Editor serialization/reload, zero invalid/dirty
- [x] Julia auto, controls, and text filtering with keyboard; mobile touch-target probe
- [x] Mies automatic text treatment and controls-mode radio probe
- [x] Lighthouse snapshot: accessibility 99 (only pre-existing missing main landmark)

Production starter rollout remains separately gated and is not part of this PR.